### PR TITLE
Fix Cypress:Changed name of env variables to contain CYPRESS_

### DIFF
--- a/.github/workflows/ssg-cypress-tests.yml
+++ b/.github/workflows/ssg-cypress-tests.yml
@@ -14,10 +14,10 @@ jobs:
          # Install NPM dependencies - using peer dependencies
          # cypress-image-snapshot and #cypress-mochawesome-reports spits out legacy dependencies
          # and fails the build.
-         - name: Cypress install
+         - name: CYPRESS install
            run: npm install --legacy-peer-deps
          # Run cypress tests
-         - name: Cypress run
+         - name: CYPRESS run
            uses: cypress-io/github-action@v5
            with:
               install: false

--- a/.github/workflows/ssg-cypress-tests.yml
+++ b/.github/workflows/ssg-cypress-tests.yml
@@ -2,8 +2,8 @@ name: SSG Login Example
 on: push
 
 env:
-   USERNAME: ${{secrets.USERNAME}}
-   PASSWORD: ${{secrets.PASSWORD}}
+   USERNAME: ${{secrets.CYPRESS_USERNAME}}
+   PASSWORD: ${{secrets.CYPRESS_PASSWORD}}
 
 jobs:
    cypress-run:

--- a/cypress/e2e/PageObjectModel/Login/Login.cy.js
+++ b/cypress/e2e/PageObjectModel/Login/Login.cy.js
@@ -15,7 +15,7 @@ describe('Given a user visits the Practice Login page', () => {
    context('When a user enters valid login credentials', () => {
       it('Then a user shall be able to login', () => {
          loginAction.enterUsername(Cypress.env('USERNAME'));
-         loginAction.enterPassword(Cypress.env('PASSWORD'));
+         loginAction.enterPassword(Cypress.env('PASSWORD'), { log: false });
          loginAction.clickLogin();
          cy.location().should((loc) => {
             expect(loc.pathname).to.eq('/secure');
@@ -32,7 +32,7 @@ describe('Given a user visits the Practice Login page', () => {
    context('When a user enters invalid username credentials', () => {
       it('Then an invalid username message shall appear', () => {
          loginAction.enterUsername('dummyUsername');
-         loginAction.enterPassword(Cypress.env('PASSWORD'));
+         loginAction.enterPassword(Cypress.env('PASSWORD'), { log: false });
          loginAction.clickLogin();
          cy.location().should((loc) => {
             expect(loc.pathname).not.to.eq('/secure');


### PR DESCRIPTION
**Description:**
Changed env variable name in workflow

- [X] Are all files committed
- [X] Did you run tests locally and get 100% pass rate
- [X] Did you assign an owner to PR
- [X] Did you add "test" and "cypress" git-tags to PR

**Created By:**
Cesar Gaudin